### PR TITLE
Refactor: Simplify interval beep to a single sound

### DIFF
--- a/src/hooks/useStopwatch.ts
+++ b/src/hooks/useStopwatch.ts
@@ -36,9 +36,7 @@ export function useStopwatch(initialInterval = 30000) {
     // Ensure audio is initialized before attempting to play.
     // This is particularly important for browsers requiring user interaction.
     initAudio(); 
-    playBeep(880, 300, 1.0); // Main beep (Higher frequency: 880 Hz for prominence)
-    setTimeout(() => playBeep(660, 300, 1.0), 50); // Second beep, slightly different tone
-    setTimeout(() => playBeep(770, 300, 1.0), 100); // Third beep, another variation
+    playBeep(880, 300, 1.0); // Play a single, clear beep.
   }, []); // This function has no dependencies from the hook's scope, so it's stable.
 
   // Effect to calculate and set the `nextBeepAtRef.current` timestamp.


### PR DESCRIPTION
The previous implementation used a sequence of three beeps for intervals. This change simplifies the interval beep to a single, clear sound (880Hz, 300ms) by modifying the `triggerIntervalBeepSequence` function in `useStopwatch.ts`.

This change aims to align the beeping behavior more closely with typical expectations for a stopwatch interval notification and potentially addresses an unspecified issue where the previous complex beep sequence was not functioning 'as specified'. Audio initialization and fallback mechanisms remain in place.